### PR TITLE
Add field schema to metadata and guarantee required fields

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -12,28 +12,36 @@ const geometryTypes = [
     'MultiPolygon'
 ]
 
-function Model(koop) {}
+function Model(koop) { }
 
-Model.prototype.getData = function(req, callback) {
+Model.prototype.getData = function (req, callback) {
     const layerName = req.params.id
     const host = req.params.host
     const qs = Object.assign({}, config.archesHosts[host].layers[layerName])
     const geometryType = qs.type || geometryTypes[req.params.layer]
-    let propertyMap = null
+    let propertyMap = {}
     if (qs.properties) {
         propertyMap = qs.properties
         delete qs.properties
     }
     qs.type = geometryType
-    
+
+    //required fields
+    let requiredFields = ["resourceinstanceid", "nodeid", "tileid"]
+    for (requiredField in requiredFields) {
+        let fieldname = requiredFields[requiredField]
+        propertyMap[fieldname] = fieldname
+    }
+
     request({
         url: `${config.archesHosts[host].url}/geojson`,
         qs: qs
     }, (err, res, geojson) => {
         if (err) return callback(err)
-        
-        geojson.features.forEach(function(feature) {
+
+        geojson.features.forEach(function (feature) {
             if (qs.nodeid) feature.properties.nodeid = qs.nodeid
+
             if (propertyMap) {
                 let properties = {}
                 for (let incomingKey in propertyMap) {
@@ -54,12 +62,43 @@ Model.prototype.getData = function(req, callback) {
 
         geojson.ttl = config.cacheTimeout
 
+        fieldset = []
+
+        fieldset.push({
+            "name": "OBJECTID",
+            "type": "esriFieldTypeOID",
+            "alias": "OBJECTID",
+            "sqlType": "sqlTypeInteger",
+            "domain": null,
+            "defaultValue": null,
+            "editable": false,
+            "nullable": false
+        })
+
+        if (propertyMap) {
+            for (property in propertyMap) {
+                fieldset.push({
+                    "name": propertyMap[property],
+                    "type": "esriFieldTypeString",
+                    "alias": propertyMap[property],
+                    "sqlType": "sqlTypeOther",
+                    "domain": null,
+                    "defaultValue": null,
+                    "length": 128,
+                    "editable": false,
+                    "nullable": false
+                })
+            }
+        }
+
+
         geojson.metadata = {
             name: layerName,
             displayField: qs.displayField,
             title: 'Koop Arches Provider',
             geometryType: geometryType,
-            idField: 'OBJECTID'
+            idField: 'OBJECTID',
+            fields: fieldset
         }
 
         callback(null, geojson)


### PR DESCRIPTION
See issue #16 and #17

- Ensured that the resourceinstanceid, tileid and nodeid properties are alway included to support the addin.
- Added the fields to the meta data in the event that the layer is empty.